### PR TITLE
Add timeout timer for failed IdP requests

### DIFF
--- a/example/proxy_conf.yaml.example
+++ b/example/proxy_conf.yaml.example
@@ -15,6 +15,7 @@ MICRO_SERVICES:
   - "plugins/microservices/static_attributes.yaml"
 USER_ID_HASH_SALT: "61a89d2db0b9e1e27d490d050b478fe71f352fddd3528a44157f43e339c6c62f2362fb413179937d96172bf84233317"
 LOGGING:
+  fail_timeout: 60
   version: 1
   formatters:
     simple:

--- a/src/satosa/base.py
+++ b/src/satosa/base.py
@@ -70,7 +70,7 @@ class SATOSABase(object):
             self._link_micro_services(self.response_micro_services, self._auth_resp_finish)
 
         self.module_router = ModuleRouter(frontends, backends,
-                                          self.request_micro_services + self.response_micro_services)
+                                          self.request_micro_services + self.response_micro_services, config)
 
     def _link_micro_services(self, micro_services, finisher):
         if not micro_services:
@@ -293,7 +293,7 @@ class SATOSABase(object):
                            exc_info=True)
             raise SATOSAUnknownError("Unknown error") from err
         return resp
- 
+
 
 class SAMLBaseModule(object):
     KEY_ENTITYID_ENDPOINT = 'entityid_endpoint'


### PR DESCRIPTION
This patch adds a logline for IdP requests that timeout for some reason (hardcoded). It doesn't have a configuration option yet.